### PR TITLE
Improve accuracy of Trakt.tv search

### DIFF
--- a/IMDb_Scout.user.js
+++ b/IMDb_Scout.user.js
@@ -781,7 +781,7 @@ var icon_sites = [
       'showByDefault': false},
   {   'name': 'trakt.tv',
       'icon': 'https://walter.trakt.tv/hotlink-ok/public/favicon.ico',
-      'searchUrl': 'https://trakt.tv/search?query=%search_string%',
+      'searchUrl': 'https://trakt.tv/search/imdb?query=%tt%',
       'showByDefault': false}
 ];
 


### PR DESCRIPTION
Trakt.tv allows for direct lookups of IMDb IDs, so there's no need to do a "search string" type search. Using the IMDb ID search url results in much better results.